### PR TITLE
Disabled DispatchQueue extension for Linux and added  allTests array …

### DIFF
--- a/Sources/Time+Foundation.swift
+++ b/Sources/Time+Foundation.swift
@@ -32,6 +32,7 @@ extension Date {
     
 }
 
+#if !os(Linux)
 extension DispatchQueue {
     
     @available(OSXApplicationExtension 10.10, *)
@@ -45,3 +46,4 @@ extension DispatchQueue {
     }
     
 }
+#endif

--- a/Tests/TimeTests/TimeTests.swift
+++ b/Tests/TimeTests/TimeTests.swift
@@ -47,6 +47,13 @@ class TimeTests: XCTestCase {
         print(3.hours.inSeconds)
     }
     
+    static let allTests = [
+        ("testSome", testSome),
+        ("testCompare", testCompare),
+        ("testConverted", testConverted),
+        ("testConversionRate", testConversionRate),
+        ("testUsage", testUsage)
+    ]
 }
 
 let tenMinutes = Interval<Minute>(10)


### PR DESCRIPTION
…for Linux tests

The DispatchQueue currently isn't available on Linux.  So, to enable Linux usage I added a #if !os(Linux) around the extension.

Additionally, I added the allTests array specification so that the tests would run on Linux.  I ran 'swift test' on Ubuntu and all pass as expected.